### PR TITLE
Rework telemetry UI and add run controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,56 +1,460 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <title>Idle ARPG - Combat Test </title>
+        <title>Idle ARPG - Combat Telemetry Console</title>
         <style>
+            :root {
+                --bg-base: #05060d;
+                --bg-panel: rgba(12, 12, 24, 0.85);
+                --bg-panel-alt: rgba(18, 18, 34, 0.85);
+                --border-panel: rgba(60, 60, 90, 0.6);
+                --accent-primary: #8da0ff;
+                --accent-secondary: #7c84ff;
+                --text-muted: #5f6ba6;
+                --text-soft: #cfd2ff;
+                --shadow-strong: 0 18px 40px rgba(0, 0, 0, 0.45);
+            }
+
+            * {
+                box-sizing: border-box;
+            }
+
             body {
-                font-family: monospace;
-                background: #0f0f0f;
+                margin: 0;
+                font-family: 'JetBrains Mono', 'Fira Code', 'Source Code Pro', monospace;
+                background: radial-gradient(circle at top, #0a0a17 0%, #05060d 55%, #030308 100%);
                 color: #f8f5f5;
-                padding: 200px;
+                min-height: 100vh;
             }
-            #combat-log {
-                height: 400px;
-                overflow-y: auto;
-                border: 2px solid #130879;
-                padding: 10px;
-                margin-top: 20px;
+
+            #app {
+                display: grid;
+                grid-template-rows: auto 1fr auto;
+                min-height: 100vh;
             }
-            .damage { color: #ff6b6b; }
-            .heal { color: #51cf66; }
-            .mana { color: #339af0; }
-            .player-magic { color: #4dabf7; font-weight: bold; }
-            .system { color: #868e96; }
-            .melee { color: #ffa726; font-style: italic}
-            .loot { color: #ffd93d; font-weight: bold; }
-            
-            /* Windfury-specific styling */
-            .windfury {
-                background: linear-gradient(90deg, transparent, rgba(81, 207, 102, 0.1), transparent);
-                border-left: 2px solid #51cf66;
-                padding-left: 8px;
-                margin-left: -8px;
-            }
-            
-            /* Combat Arena */
-            #combat-arena {
+
+            #ui-header {
                 display: flex;
                 justify-content: space-between;
                 align-items: center;
-                padding: 40px;
-                background: #000000;
-                border: 2px solid #333;
-                margin: 20px 0;
-                min-height: 200px;
+                gap: 20px;
+                padding: 24px 36px;
+                background: linear-gradient(90deg, rgba(24, 24, 54, 0.95), rgba(34, 34, 72, 0.9));
+                border-bottom: 1px solid rgba(70, 70, 110, 0.6);
+                box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+                position: sticky;
+                top: 0;
+                z-index: 50;
+            }
+
+            .header-title {
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+            }
+
+            .header-title h1 {
+                margin: 0;
+                font-size: 20px;
+                text-transform: uppercase;
+                letter-spacing: 0.28em;
+                color: #ffffff;
+            }
+
+            .header-title .subtitle {
+                font-size: 12px;
+                color: var(--accent-secondary);
+                letter-spacing: 0.38em;
+                text-transform: uppercase;
+            }
+
+            .header-controls {
+                display: flex;
+                flex-wrap: wrap;
+                align-items: center;
+                justify-content: flex-end;
+                gap: 12px;
+            }
+
+            .control-group {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                padding: 6px 12px;
+                background: rgba(16, 16, 40, 0.7);
+                border: 1px solid rgba(68, 68, 120, 0.6);
+                border-radius: 8px;
+                box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.25);
+            }
+
+            .control-group label {
+                font-size: 11px;
+                text-transform: uppercase;
+                letter-spacing: 0.22em;
+                color: #9fa6ff;
+            }
+
+            .header-controls button,
+            .header-controls select {
+                background: rgba(30, 30, 70, 0.9);
+                border: 1px solid rgba(92, 92, 160, 0.6);
+                color: #f4f6ff;
+                padding: 6px 12px;
+                border-radius: 5px;
+                font-size: 12px;
+                font-family: inherit;
+                text-transform: uppercase;
+                letter-spacing: 0.16em;
+                cursor: pointer;
+                transition: border-color 0.2s ease, box-shadow 0.2s ease;
+            }
+
+            .header-controls button:hover,
+            .header-controls select:hover {
+                border-color: rgba(160, 160, 255, 0.8);
+                box-shadow: 0 0 12px rgba(124, 132, 255, 0.35);
+            }
+
+            .header-controls button:disabled {
+                opacity: 0.45;
+                cursor: not-allowed;
+                box-shadow: none;
+            }
+
+            #run-status {
+                padding: 6px 12px;
+                border-radius: 5px;
+                background: rgba(124, 132, 255, 0.18);
+                border: 1px solid rgba(124, 132, 255, 0.45);
+                color: #d0d3ff;
+                font-size: 12px;
+                letter-spacing: 0.22em;
+                text-transform: uppercase;
+            }
+
+            #ui-grid {
+                display: grid;
+                grid-template-columns: 320px 1fr 360px;
+                gap: 28px;
+                padding: 28px 36px 20px;
+                background: linear-gradient(180deg, rgba(8, 8, 18, 0.92), rgba(3, 3, 10, 0.98));
+            }
+
+            #entity-stack,
+            #timeline-area,
+            #rules-column {
+                background: var(--bg-panel);
+                border: 1px solid var(--border-panel);
+                border-radius: 16px;
+                padding: 20px;
+                box-shadow: var(--shadow-strong);
+                backdrop-filter: blur(6px);
+            }
+
+            #entity-stack,
+            #rules-column {
+                display: flex;
+                flex-direction: column;
+                gap: 18px;
+                max-height: calc(100vh - 220px);
+                overflow-y: auto;
+            }
+
+            #entity-stack .panel-title,
+            #rules-column .panel-title,
+            #timeline-area .panel-title {
+                margin: 0;
+                font-size: 14px;
+                letter-spacing: 0.26em;
+                text-transform: uppercase;
+                color: var(--accent-primary);
+            }
+
+            .panel-subtitle {
+                font-size: 11px;
+                color: var(--text-muted);
+                text-transform: uppercase;
+                letter-spacing: 0.28em;
+                margin-top: -6px;
+                margin-bottom: 12px;
+            }
+
+            .entity-card {
+                background: var(--bg-panel-alt);
+                border: 1px solid rgba(70, 70, 110, 0.55);
+                border-radius: 12px;
+                padding: 16px;
+                display: flex;
+                flex-direction: column;
+                gap: 14px;
+            }
+
+            .entity-card-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                gap: 12px;
+            }
+
+            .entity-name {
+                font-size: 16px;
+                font-weight: 600;
+                letter-spacing: 0.08em;
+            }
+
+            .entity-role {
+                font-size: 11px;
+                text-transform: uppercase;
+                letter-spacing: 0.22em;
+                color: var(--accent-secondary);
+            }
+
+            .entity-status-badge {
+                font-size: 10px;
+                padding: 4px 10px;
+                border-radius: 999px;
+                border: 1px solid rgba(124, 255, 132, 0.4);
+                background: rgba(124, 255, 132, 0.12);
+                color: #a6ffaf;
+                letter-spacing: 0.18em;
+                text-transform: uppercase;
+            }
+
+            .entity-status-badge.danger {
+                border-color: rgba(255, 124, 124, 0.45);
+                background: rgba(255, 124, 124, 0.15);
+                color: #ff9b9b;
+            }
+
+            .entity-metrics {
+                display: grid;
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+                gap: 10px 16px;
+                font-size: 12px;
+                color: var(--text-soft);
+            }
+
+            .entity-metrics span.label {
+                display: block;
+                font-size: 10px;
+                letter-spacing: 0.18em;
+                text-transform: uppercase;
+                color: #7179b3;
+            }
+
+            .entity-metrics span.value {
+                display: block;
+                font-weight: 600;
+                color: #f4f6ff;
+                letter-spacing: 0.06em;
+            }
+
+            .resist-grid {
+                display: grid;
+                grid-template-columns: repeat(3, minmax(0, 1fr));
+                gap: 10px;
+            }
+
+            .resist-item {
+                background: rgba(30, 30, 58, 0.8);
+                border: 1px solid rgba(74, 74, 120, 0.55);
+                border-radius: 10px;
+                padding: 8px;
+                text-align: center;
+                color: #b4bbff;
+            }
+
+            .resist-icon {
+                display: block;
+                font-size: 16px;
+                margin-bottom: 4px;
+            }
+
+            .resist-value {
+                display: block;
+                font-size: 13px;
+                font-weight: 600;
+                color: #f6f8ff;
+            }
+
+            .resist-label {
+                display: block;
+                font-size: 9px;
+                letter-spacing: 0.22em;
+                text-transform: uppercase;
+                color: #6a72aa;
+                margin-top: 2px;
+            }
+
+            .summon-status {
+                background: rgba(24, 24, 46, 0.85);
+                border: 1px solid rgba(80, 80, 130, 0.5);
+                border-radius: 10px;
+                padding: 10px 12px;
+                display: flex;
+                flex-direction: column;
+                gap: 6px;
+            }
+
+            .summon-status .section-label {
+                font-size: 10px;
+                letter-spacing: 0.24em;
+                text-transform: uppercase;
+                color: var(--accent-secondary);
+            }
+
+            .summon-row {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                gap: 10px;
+                font-size: 12px;
+                color: #d7daff;
+            }
+
+            #timeline-area {
+                display: flex;
+                flex-direction: column;
+                gap: 18px;
+                max-height: calc(100vh - 220px);
+                overflow-y: auto;
+            }
+
+            #timeline-area .panel-title {
+                margin-bottom: -4px;
+            }
+
+            .timeline-section {
+                background: rgba(16, 16, 36, 0.85);
+                border: 1px solid rgba(64, 64, 110, 0.55);
+                border-radius: 14px;
+                padding: 18px;
+                display: flex;
+                flex-direction: column;
+                gap: 14px;
+            }
+
+            .section-title {
+                margin: 0;
+                font-size: 12px;
+                letter-spacing: 0.24em;
+                text-transform: uppercase;
+                color: var(--accent-primary);
+            }
+
+            .timeline-track {
+                display: flex;
+                align-items: center;
+                gap: 14px;
+            }
+
+            .timeline-track.column {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+
+            .timeline-label {
+                font-size: 11px;
+                letter-spacing: 0.22em;
+                text-transform: uppercase;
+                color: #6f79b4;
+                width: 160px;
+                flex-shrink: 0;
+            }
+
+            .timeline-bar {
                 position: relative;
+                flex: 1;
+                height: 18px;
+                border-radius: 999px;
+                background: rgba(36, 36, 70, 0.75);
+                border: 1px solid rgba(70, 70, 120, 0.6);
                 overflow: hidden;
             }
-            
-            /* ASCII Trees Background */
+
+            .timeline-bar.small {
+                height: 14px;
+            }
+
+            .timeline-progress {
+                position: absolute;
+                left: 0;
+                top: 0;
+                height: 100%;
+                width: 0;
+                background: linear-gradient(90deg, #7c84ff, #c69bff);
+                box-shadow: 0 0 14px rgba(124, 132, 255, 0.35);
+                transition: width 0.15s linear;
+            }
+
+            .timeline-track.aura .timeline-progress {
+                background: linear-gradient(90deg, #51cf66, #8dffb0);
+                box-shadow: 0 0 14px rgba(81, 207, 102, 0.35);
+            }
+
+            .timeline-text {
+                position: absolute;
+                left: 50%;
+                top: 50%;
+                transform: translate(-50%, -50%);
+                font-size: 11px;
+                color: #f8faff;
+                letter-spacing: 0.06em;
+                pointer-events: none;
+                text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+            }
+
+            .timeline-empty {
+                font-size: 10px;
+                letter-spacing: 0.24em;
+                text-transform: uppercase;
+                color: #565f95;
+                padding: 8px 0;
+            }
+
+            .timeline-summon-wrapper {
+                display: flex;
+                flex-direction: column;
+                gap: 10px;
+                width: 100%;
+            }
+
+            .summon-bar {
+                display: flex;
+                flex-direction: column;
+                gap: 6px;
+                width: 100%;
+            }
+
+            .summon-bar .summon-name {
+                font-size: 11px;
+                letter-spacing: 0.24em;
+                text-transform: uppercase;
+                color: var(--accent-secondary);
+            }
+
+            #telemetry-panels.hidden,
+            #combat-arena-section.hidden {
+                display: none !important;
+            }
+
+            #combat-arena {
+                position: relative;
+                min-height: 240px;
+                border-radius: 14px;
+                border: 1px solid rgba(70, 70, 110, 0.6);
+                background: radial-gradient(circle at center, rgba(28, 28, 52, 0.9) 0%, rgba(10, 10, 22, 0.95) 55%, rgba(3, 3, 9, 0.98) 100%);
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                padding: 42px;
+                overflow: hidden;
+            }
+
             .arena-trees {
                 position: absolute;
                 font-family: 'Courier New', monospace;
-                color: #1a331a;
+                color: rgba(45, 90, 45, 0.35);
                 font-size: 14px;
                 line-height: 0.9;
                 white-space: pre;
@@ -58,36 +462,7 @@
                 pointer-events: none;
                 z-index: 1;
             }
-            
-            .trees-left {
-                left: 10px;
-                top: 50%;
-                transform: translateY(-50%);
-            }
-            
-            .trees-right {
-                right: 10px;
-                top: 50%;
-                transform: translateY(-50%);
-            }
-            
-            .trees-top {
-                top: 5px;
-                left: 50%;
-                transform: translateX(-50%);
-                display: flex;
-                gap: 40px;
-            }
-            
-            .trees-bottom {
-                bottom: 5px;
-                left: 50%;
-                transform: translateX(-50%);
-                display: flex;
-                gap: 50px;
-            }
-            
-            /* Character Containers */
+
             .character-slot {
                 display: flex;
                 flex-direction: column;
@@ -96,114 +471,73 @@
                 position: relative;
                 z-index: 10;
             }
-            
-            /* Sprite Containers */
+
             .sprite-container {
-                width: 40px;
-                height: 45px;
+                width: 70px;
+                height: 80px;
                 display: flex;
                 align-items: center;
                 justify-content: center;
                 position: relative;
             }
-            
+
             .sprite {
-                font-size: 24px;
+                font-size: 30px;
                 font-weight: bold;
                 font-family: 'Courier New', monospace;
                 user-select: none;
                 transition: transform 0.1s ease-out;
+                text-shadow: 0 0 14px rgba(74, 158, 255, 0.6);
             }
-            
+
             #player-sprite {
                 color: #4a9eff;
-                text-shadow: 0 0 10px #4a9eff;
-                font-size: 28px;
             }
-            
+
             #enemy-sprite {
                 color: #f5f5dc;
-                text-shadow: 0 0 10px #ff4444;
-                font-size: 13px;
+                text-shadow: 0 0 12px rgba(255, 68, 68, 0.6);
+                font-size: 15px;
                 line-height: 0.8;
                 white-space: pre;
                 text-align: center;
-                font-family: 'Courier New', monospace;
             }
-            
-            /* Remove idle floating animation 
-            @keyframes idle-float {
-                0%, 100% { transform: translateY(0); }
-                50% { transform: translateY(-3px); }
-            }
-            */
-            
-            /* Attack animations - CRUNCHIER */
-            .attacking {
-                animation: attack-lunge 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55) !important;
-            }
-            
-            @keyframes attack-lunge {
-                0% { transform: translateX(0) scale(1); }
-                40% { transform: translateX(15px) scale(1.3); }
-                100% { transform: translateX(0) scale(1); }
-            }
-            
-            .enemy-attacking {
-                animation: enemy-attack-lunge 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55) !important;
-            }
-            
-            @keyframes enemy-attack-lunge {
-                0% { transform: translateX(0) scale(1); }
-                40% { transform: translateX(-15px) scale(1.3); }
-                100% { transform: translateX(0) scale(1); }
-            }
-            
-            /* Damage taken animation - CRUNCHIER */
-            .damaged {
-                animation: damage-flash 0.15s !important;
-            }
-            
-            @keyframes damage-flash {
-                0% { transform: scale(1); filter: brightness(1); }
-                50% { transform: scale(0.9); filter: brightness(2) hue-rotate(180deg); }
-                100% { transform: scale(1); filter: brightness(1); }
-            }
-            
-            /* Health and Mana Bars */
+
             .bar-container {
-                width: 100px;
-                height: 14px;
-                background: #1a1a1a;
-                border: 1px solid #444;
+                width: 160px;
+                height: 18px;
+                background: rgba(18, 18, 32, 0.9);
+                border: 1px solid rgba(60, 60, 90, 0.65);
+                border-radius: 999px;
                 position: relative;
+                overflow: hidden;
             }
-            
+
             .health-bar {
                 height: 100%;
-                background: linear-gradient(to right, #c62828, #ef5350);
+                background: linear-gradient(90deg, #c62828, #ef5350);
                 transition: width 0.3s ease;
                 position: relative;
             }
-            
+
             .mana-bar {
                 height: 100%;
-                background: linear-gradient(to right, #1565c0, #42a5f5);
+                background: linear-gradient(90deg, #1565c0, #42a5f5);
                 transition: width 0.3s ease;
+                position: relative;
             }
-            
+
             .bar-text {
                 position: absolute;
                 width: 100%;
                 text-align: center;
                 font-size: 10px;
-                line-height: 14px;
+                line-height: 18px;
                 color: white;
-                text-shadow: 1px 1px 2px black;
+                text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);
                 pointer-events: none;
             }
-            
-            /* Damage Splats - RuneScape Style */
+
             .damage-splat {
                 position: absolute;
                 width: 50px;
@@ -212,13 +546,13 @@
                 z-index: 100;
                 animation: splat-appear 0.05s cubic-bezier(0.175, 0.885, 0.32, 1.275);
             }
-            
+
             .splat-bg {
                 position: absolute;
                 width: 100%;
                 height: 100%;
             }
-            
+
             .splat-text {
                 position: absolute;
                 width: 100%;
@@ -232,7 +566,7 @@
                 text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.9), -1px -1px 2px rgba(0, 0, 0, 0.9);
                 pointer-events: none;
             }
-            
+
             @keyframes splat-appear {
                 0% {
                     transform: scale(0);
@@ -241,172 +575,67 @@
                     transform: scale(1);
                 }
             }
-            
-            /* Old damage number styles - keeping for reference */
-            .damage-number {
-                position: absolute;
-                font-size: 20px;
-                font-weight: bold;
-                pointer-events: none;
-                z-index: 100;
-                opacity: 1;
-                transition: opacity 0.2s ease-out, top 0.15s ease-out;
-                text-shadow: 2px 2px 2px rgba(0, 0, 0, 0.9);
-                animation: pop-in 0.05s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+
+            .attacking {
+                animation: attack-lunge 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55) !important;
             }
-            
-            @keyframes pop-in {
+
+            @keyframes attack-lunge {
                 0% {
-                    transform: scale(0);
+                    transform: translateX(0) scale(1);
+                }
+                40% {
+                    transform: translateX(18px) scale(1.28);
+                }
+                100% {
+                    transform: translateX(0) scale(1);
+                }
+            }
+
+            .enemy-attacking {
+                animation: enemy-attack-lunge 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55) !important;
+            }
+
+            @keyframes enemy-attack-lunge {
+                0% {
+                    transform: translateX(0) scale(1);
+                }
+                40% {
+                    transform: translateX(-18px) scale(1.28);
+                }
+                100% {
+                    transform: translateX(0) scale(1);
+                }
+            }
+
+            .damaged {
+                animation: damage-flash 0.15s !important;
+            }
+
+            @keyframes damage-flash {
+                0% {
+                    transform: scale(1);
+                    filter: brightness(1);
+                }
+                50% {
+                    transform: scale(0.9);
+                    filter: brightness(2) hue-rotate(180deg);
                 }
                 100% {
                     transform: scale(1);
+                    filter: brightness(1);
                 }
             }
-            
-            .damage-holy {
-                color: #64b5f6;
-                text-shadow: 0 0 4px #2196f3, 2px 2px 2px rgba(0, 0, 0, 0.9);
-            }
-            
-            .damage-physical {
-                color: #ffa726;
-                text-shadow: 0 0 4px #ff6600, 2px 2px 2px rgba(0, 0, 0, 0.9);
-            }
-            
-            .damage-enemy {
-                color: #ef5350;
-                text-shadow: 0 0 4px #c62828, 2px 2px 2px rgba(0, 0, 0, 0.9);
-            }
-            
-            /* Stats Display */
-            #stats {
-                display: flex;
-                justify-content: space-between;
-                gap: 20px;
-                margin-bottom: 20px;
-            }
-            
-            .stats-panel {
-                background: #2a2a2a;
-                border: 1px solid #444;
-                padding: 10px;
-                flex: 1;
-            }
-            
-            .player-stats {
-                text-align: left;
-            }
-            
-            .enemy-stats {
-                text-align: right;
-            }
-            
-            /* Combat AI Panel */
-            #combat-ai-panel {
-                background: #2a2a2a;
-                border: 1px solid #444;
-                padding: 15px;
-                margin-top: 20px;
-            }
-            
-            #combat-ai-panel h3 {
-                margin-top: 0;
-                color: #4a9eff;
-            }
-            
-            .ai-rule {
-                background: #1a1a1a;
-                border: 1px solid #333;
-                padding: 10px;
-                margin: 10px 0;
-                display: flex;
-                align-items: center;
-                gap: 10px;
-            }
-            
-            .rule-priority {
-                color: #868e96;
-                font-weight: bold;
-                margin-right: 5px;
-            }
-            
-            .rule-controls {
-                display: flex;
-                flex-direction: column;
-                gap: 2px;
-            }
-            
-            .rule-controls button {
-                background: #333;
-                border: 1px solid #555;
-                color: white;
-                cursor: pointer;
-                padding: 2px 6px;
-                font-size: 10px;
-            }
-            
-            .rule-controls button:hover {
-                background: #444;
-            }
-            
-            .rule-content {
-                flex: 1;
-                display: flex;
-                align-items: center;
-                gap: 5px;
-            }
-            
-            .rule-content input {
-                width: 50px;
-                background: #333;
-                border: 1px solid #555;
-                color: white;
-                padding: 2px 5px;
-            }
-            
-            .rule-content select {
-                background: #333;
-                border: 1px solid #555;
-                color: white;
-                padding: 2px 5px;
-            }
-            
-            .rule-delete {
-                background: #8b0000;
-                border: 1px solid #a00;
-                color: white;
-                cursor: pointer;
-                padding: 2px 8px;
-            }
-            
-            .rule-delete:hover {
-                background: #a00;
-            }
-            
-            #add-rule-btn {
-                background: #4a9eff;
-                border: none;
-                color: white;
-                padding: 5px 15px;
-                cursor: pointer;
-                margin-top: 10px;
-            }
-            
-            #add-rule-btn:hover {
-                background: #5ab0ff;
-            }
-            
-            /* Ability Cooldown Display */
+
             .ability-cooldowns {
                 display: flex;
-                gap: 10px;
-                margin-top: 10px;
+                gap: 12px;
+                margin-top: 6px;
             }
-            
+
             .ability-icon {
-                width: 48px;
-                height: 48px;
+                width: 52px;
+                height: 52px;
                 position: relative;
                 border: 2px solid #4a9eff;
                 border-radius: 50%;
@@ -414,57 +643,56 @@
                 transition: transform 0.1s, box-shadow 0.2s;
                 user-select: none;
             }
-            
+
             .ability-icon:hover {
                 transform: scale(1.05);
                 box-shadow: 0 0 10px rgba(74, 158, 255, 0.5);
             }
-            
+
             .ability-icon:active {
                 transform: scale(0.95);
             }
-            
+
             .ability-icon.disabled {
                 opacity: 0.5;
                 cursor: not-allowed !important;
             }
-            
+
             .ability-icon.disabled:hover {
                 transform: scale(1);
                 box-shadow: none;
             }
-            
+
             .ability-icon:hover::after {
                 content: attr(data-tooltip);
                 position: absolute;
-                bottom: 60px;
+                bottom: 64px;
                 left: 50%;
                 transform: translateX(-50%);
-                background: #2a2a2a;
-                border: 1px solid #444;
+                background: rgba(24, 24, 40, 0.92);
+                border: 1px solid rgba(68, 68, 120, 0.6);
                 padding: 8px;
-                border-radius: 4px;
+                border-radius: 6px;
                 white-space: pre-line;
-                width: 250px;
+                width: 260px;
                 font-size: 12px;
                 z-index: 100;
                 pointer-events: none;
             }
-            
+
             .ability-icon-content {
                 width: 100%;
                 height: 100%;
                 display: flex;
                 align-items: center;
                 justify-content: center;
-                font-size: 20px;
+                font-size: 22px;
                 font-weight: bold;
                 color: #4a9eff;
                 position: relative;
                 z-index: 2;
             }
-            
-            /* Cooldown overlay - darkens the ability when on cooldown */
+
             .cooldown-overlay {
                 position: absolute;
                 top: 0;
@@ -475,18 +703,17 @@
                 background: rgba(0, 0, 0, 0.7);
                 z-index: 3;
             }
-            
-            /* Cooldown sweep - the filling circle effect */
+
             .cooldown-sweep {
                 position: absolute;
                 top: -2px;
                 left: -2px;
-                width: 52px;
-                height: 52px;
+                width: 56px;
+                height: 56px;
                 border-radius: 50%;
                 z-index: 4;
             }
-            
+
             .cooldown-text {
                 position: absolute;
                 top: 50%;
@@ -498,113 +725,476 @@
                 text-shadow: 1px 1px 2px black;
                 z-index: 5;
             }
-            
+
             .ability-ready {
                 animation: pulse-ready 1s ease-in-out infinite;
             }
-            
+
             @keyframes pulse-ready {
-                0%, 100% { box-shadow: 0 0 5px #4a9eff; }
-                50% { box-shadow: 0 0 15px #4a9eff, 0 0 25px #4a9eff; }
+                0%, 100% {
+                    box-shadow: 0 0 6px #4a9eff;
+                }
+                50% {
+                    box-shadow: 0 0 18px #4a9eff, 0 0 28px #4a9eff;
+                }
             }
-            
+
             .aura-active {
                 animation: aura-pulse 2s ease-in-out infinite;
             }
-            
+
             @keyframes aura-pulse {
-                0%, 100% { box-shadow: 0 0 10px #51cf66; }
-                50% { box-shadow: 0 0 20px #51cf66, 0 0 30px #51cf66; }
+                0%, 100% {
+                    box-shadow: 0 0 12px #51cf66;
+                }
+                50% {
+                    box-shadow: 0 0 24px #51cf66, 0 0 34px #51cf66;
+                }
             }
-            
-            @keyframes ability-activate {
-                0% { box-shadow: 0 0 0 0 rgba(74, 158, 255, 0.7); }
-                70% { box-shadow: 0 0 0 15px rgba(74, 158, 255, 0); }
-                100% { box-shadow: 0 0 0 0 rgba(74, 158, 255, 0); }
+
+            #rules-column {
+                gap: 0;
             }
-            
-            .ability-activate {
-                animation: ability-activate 0.4s;
+
+            #combat-ai-panel {
+                background: rgba(18, 18, 34, 0.88);
+                border: 1px solid rgba(70, 70, 110, 0.55);
+                border-radius: 14px;
+                padding: 18px;
+                display: flex;
+                flex-direction: column;
+                gap: 14px;
+                height: 100%;
+            }
+
+            #rules-metrics {
+                display: grid;
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+                gap: 12px;
+            }
+
+            .metric {
+                background: rgba(28, 28, 52, 0.75);
+                border: 1px solid rgba(74, 74, 120, 0.6);
+                border-radius: 10px;
+                padding: 12px;
+                text-align: center;
+            }
+
+            .metric-label {
+                display: block;
+                font-size: 10px;
+                letter-spacing: 0.26em;
+                text-transform: uppercase;
+                color: #6d74a9;
+                margin-bottom: 6px;
+            }
+
+            .metric-value {
+                font-size: 18px;
+                font-weight: 600;
+                color: #f4f6ff;
+                letter-spacing: 0.08em;
+            }
+
+            .ai-rule {
+                background: rgba(12, 12, 28, 0.9);
+                border: 1px solid rgba(70, 70, 110, 0.55);
+                border-radius: 10px;
+                padding: 12px;
+                display: grid;
+                grid-template-columns: auto 1fr auto;
+                gap: 12px;
+                align-items: center;
+            }
+
+            .rule-priority {
+                font-size: 12px;
+                color: var(--accent-primary);
+                font-weight: 600;
+            }
+
+            .rule-controls {
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+            }
+
+            .rule-controls button {
+                background: #232347;
+                border: 1px solid #42427a;
+                color: #cfd2ff;
+                padding: 2px 6px;
+                font-size: 12px;
+                border-radius: 4px;
+                cursor: pointer;
+            }
+
+            .rule-controls button:hover {
+                border-color: #6c6cff;
+            }
+
+            .rule-content {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 8px;
+                align-items: center;
+                font-size: 12px;
+                color: #d6daff;
+            }
+
+            .rule-content select,
+            .rule-content input {
+                background: #1a1a34;
+                border: 1px solid #3a3a66;
+                color: #f0f3ff;
+                padding: 4px 8px;
+                border-radius: 4px;
+                font-family: inherit;
+                font-size: 12px;
+            }
+
+            .rule-toggle {
+                display: flex;
+                align-items: center;
+                gap: 4px;
+                font-size: 11px;
+                color: var(--accent-secondary);
+                text-transform: uppercase;
+                letter-spacing: 0.16em;
+            }
+
+            .rule-delete {
+                background: #3b161a;
+                border: 1px solid #7c1f2b;
+                color: #ff6b6b;
+                padding: 4px 8px;
+                border-radius: 4px;
+                cursor: pointer;
+                font-size: 11px;
+                text-transform: uppercase;
+                letter-spacing: 0.14em;
+            }
+
+            .rule-delete:hover {
+                border-color: #ff6b6b;
+            }
+
+            #add-rule-btn {
+                align-self: flex-start;
+                background: #2d3f7c;
+                border: 1px solid #4b65d1;
+                color: #f4f6ff;
+                padding: 6px 14px;
+                border-radius: 6px;
+                cursor: pointer;
+                font-size: 12px;
+                text-transform: uppercase;
+                letter-spacing: 0.2em;
+            }
+
+            #add-rule-btn:hover {
+                border-color: #7a92ff;
+            }
+
+            #event-feed {
+                background: rgba(12, 12, 26, 0.95);
+                border-top: 1px solid rgba(70, 70, 110, 0.6);
+                padding: 20px 36px 28px;
+                box-shadow: 0 -16px 36px rgba(0, 0, 0, 0.45);
+            }
+
+            #event-feed .panel-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: baseline;
+            }
+
+            #event-feed .panel-header h2 {
+                margin: 0;
+                font-size: 14px;
+                text-transform: uppercase;
+                letter-spacing: 0.28em;
+                color: var(--accent-primary);
+            }
+
+            #combat-log {
+                margin-top: 14px;
+                max-height: 220px;
+                overflow-y: auto;
+                background: rgba(10, 10, 24, 0.86);
+                border: 1px solid rgba(60, 60, 90, 0.6);
+                border-radius: 12px;
+                padding: 14px;
+                display: flex;
+                flex-direction: column;
+                gap: 8px;
+            }
+
+            #combat-log div {
+                padding: 8px 10px;
+                border-radius: 8px;
+                background: rgba(20, 20, 40, 0.8);
+                font-size: 12px;
+                letter-spacing: 0.04em;
+                border-left: 3px solid transparent;
+            }
+
+            #combat-log .damage {
+                border-color: #ff6b6b;
+                color: #ff9a9a;
+                background: rgba(60, 0, 0, 0.35);
+            }
+
+            #combat-log .heal {
+                border-color: #51cf66;
+                color: #8cff9a;
+                background: rgba(0, 60, 20, 0.35);
+            }
+
+            #combat-log .mana {
+                border-color: #339af0;
+                color: #7bb7ff;
+                background: rgba(0, 30, 60, 0.35);
+            }
+
+            #combat-log .player-magic {
+                border-color: #4dabf7;
+                color: #9bc6ff;
+                background: rgba(15, 30, 70, 0.45);
+                font-weight: 600;
+            }
+
+            #combat-log .system {
+                border-color: #868e96;
+                color: #b7bdc5;
+                background: rgba(40, 40, 50, 0.4);
+            }
+
+            #combat-log .melee {
+                border-color: #ffa726;
+                color: #ffcd82;
+                background: rgba(60, 35, 0, 0.35);
+                font-style: italic;
+            }
+
+            #combat-log .loot {
+                border-color: #ffd93d;
+                color: #ffe17a;
+                background: rgba(70, 50, 0, 0.35);
+                font-weight: bold;
+            }
+
+            #combat-log .windfury {
+                box-shadow: inset 0 0 14px rgba(81, 207, 102, 0.25);
+                border-left-color: #51cf66;
+            }
+
+            .hidden {
+                display: none !important;
+            }
+
+            body[data-view="timeline"] #run-status {
+                background: rgba(124, 132, 255, 0.35);
+                border-color: rgba(124, 132, 255, 0.6);
+                color: #f0f2ff;
+            }
+
+            body[data-view="arena"] #run-status {
+                background: rgba(255, 124, 124, 0.22);
+                border-color: rgba(255, 124, 124, 0.5);
+                color: #ffb3b3;
             }
         </style>
     </head>
     <body>
-        <div id="stats">
-            <div class="stats-panel player-stats" id="player-stats"></div>
-            <div class="stats-panel enemy-stats" id="enemy-stats"></div>
-        </div>
-        
-        <!-- Combat Arena -->
-        <div id="combat-arena">
-            <!-- ASCII Trees Background -->
-            <div class="arena-trees" style="color: #2d5a2d; left: 10px; top: 20%;">    /\
+        <div id="app">
+            <header id="ui-header">
+                <div class="header-title">
+                    <h1>Stat-Sim Console</h1>
+                    <div class="subtitle">Telemetry-First • Idle ARPG Instrumentation</div>
+                </div>
+                <div class="header-controls">
+                    <div class="control-group">
+                        <button id="pause-btn">Pause</button>
+                        <button id="resume-btn">Resume</button>
+                        <button id="step-btn">Step</button>
+                    </div>
+                    <div class="control-group">
+                        <label for="speed-select">Speed</label>
+                        <select id="speed-select">
+                            <option value="0.5">0.5x</option>
+                            <option value="1" selected>1x</option>
+                            <option value="2">2x</option>
+                            <option value="4">4x</option>
+                        </select>
+                    </div>
+                    <div class="control-group">
+                        <label for="view-select">View</label>
+                        <select id="view-select">
+                            <option value="mixed" selected>Mixed</option>
+                            <option value="timeline">Timeline</option>
+                            <option value="arena">Arena</option>
+                        </select>
+                    </div>
+                    <div id="run-status">Running ×1</div>
+                </div>
+            </header>
+            <div id="ui-grid">
+                <aside id="entity-stack">
+                    <h2 class="panel-title">Entity Stack</h2>
+                    <div class="panel-subtitle">Actors • HP/MP bars • Resist Icons • Sparkline</div>
+                    <div class="entity-card">
+                        <div class="entity-card-header">
+                            <div>
+                                <div class="entity-role">Player</div>
+                                <div class="entity-name">Cleric</div>
+                            </div>
+                            <span class="entity-status-badge" id="player-status-badge">Ready</span>
+                        </div>
+                        <div id="player-stats"></div>
+                    </div>
+                    <div class="entity-card">
+                        <div class="entity-card-header">
+                            <div>
+                                <div class="entity-role">Target</div>
+                                <div class="entity-name" id="enemy-name">Skeleton</div>
+                            </div>
+                            <span class="entity-status-badge" id="enemy-status-badge">Live</span>
+                        </div>
+                        <div id="enemy-stats"></div>
+                    </div>
+                </aside>
+                <main id="timeline-area">
+                    <h2 class="panel-title">Timelines</h2>
+                    <div class="panel-subtitle">Casts • Cooldowns • Buff/Debuff Bands • Proc Pulses</div>
+                    <section class="timeline-section" id="combat-arena-section">
+                        <h3 class="section-title">Combat Space</h3>
+                        <div id="combat-arena">
+                            <div class="arena-trees" style="left: 12px; top: 22%;">    /\
    /--\
   /----\</div>
-            <div class="arena-trees" style="color: #1f4a1f; left: 80px; top: 60%;">   /\
+                            <div class="arena-trees" style="left: 80px; top: 60%;">   /\
   /--\
  /----\</div>
-            <div class="arena-trees" style="color: #2d5a2d; right: 10px; top: 25%;">    /\
+                            <div class="arena-trees" style="right: 12px; top: 24%;">    /\
    /--\
   /----\</div>
-            <div class="arena-trees" style="color: #1f4a1f; right: 90px; top: 55%;">   /\
+                            <div class="arena-trees" style="right: 90px; top: 56%;">   /\
   /--\
  /----\</div>
-            <div class="arena-trees" style="color: #1a331a; top: 10px; left: 20%;">  /\
+                            <div class="arena-trees" style="top: 10px; left: 22%;">  /\
  /--\
 /----\</div>
-            <div class="arena-trees" style="color: #1a331a; top: 15px; right: 30%;">  /\
+                            <div class="arena-trees" style="top: 16px; right: 32%;">  /\
  /--\
 /----\</div>
-            <div class="arena-trees" style="color: #1f4a1f; bottom: 20px; left: 25%;">  /\
+                            <div class="arena-trees" style="bottom: 24px; left: 26%;">  /\
  /--\
 /----\</div>
-            <div class="arena-trees" style="color: #1f4a1f; bottom: 25px; right: 20%;">  /\
+                            <div class="arena-trees" style="bottom: 26px; right: 22%;">  /\
  /--\
 /----\</div>
-            
-            <!-- Player Side -->
-            <div class="character-slot">
-                <div class="sprite-container">
-                    <div id="player-sprite" class="sprite">✦</div>
-                </div>
-                <div class="bar-container">
-                    <div id="player-health-bar" class="health-bar" style="width: 100%">
-                        <div class="bar-text">100/100</div>
-                    </div>
-                </div>
-                <div class="bar-container">
-                    <div id="player-mana-bar" class="mana-bar" style="width: 100%">
-                        <div class="bar-text">100/100</div>
-                    </div>
-                </div>
-            </div>
-            
-            <!-- Summon Container - positioned in front of player -->
-            <div id="summon-container" style="position: absolute; left: 0; bottom: 0; width: 100%; height: 100%; pointer-events: none; z-index: 8;"></div>
-            
-            <!-- Enemy Side -->
-            <div class="character-slot">
-                <div class="sprite-container">
-                    <div id="enemy-sprite" class="sprite">0
+                            <div class="character-slot">
+                                <div class="sprite-container">
+                                    <div id="player-sprite" class="sprite">✦</div>
+                                </div>
+                                <div class="bar-container">
+                                    <div id="player-health-bar" class="health-bar" style="width: 100%">
+                                        <div class="bar-text">100/100</div>
+                                    </div>
+                                </div>
+                                <div class="bar-container">
+                                    <div id="player-mana-bar" class="mana-bar" style="width: 100%">
+                                        <div class="bar-text">100/100</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="summon-container" style="position: absolute; left: 0; bottom: 0; width: 100%; height: 100%; pointer-events: none; z-index: 8;"></div>
+                            <div class="character-slot">
+                                <div class="sprite-container">
+                                    <div id="enemy-sprite" class="sprite">0
 /|\
 /\</div>
-                </div>
-                <div class="bar-container">
-                    <div id="enemy-health-bar" class="health-bar" style="width: 100%">
-                        <div class="bar-text">100/100</div>
+                                </div>
+                                <div class="bar-container">
+                                    <div id="enemy-health-bar" class="health-bar" style="width: 100%">
+                                        <div class="bar-text">100/100</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                    <div id="telemetry-panels">
+                        <section class="timeline-section">
+                            <h3 class="section-title">Ability & Cooldown Tracks</h3>
+                            <div class="timeline-track">
+                                <div class="timeline-label">Melee Swing</div>
+                                <div class="timeline-bar">
+                                    <div class="timeline-progress" id="timeline-melee"></div>
+                                    <span class="timeline-text" id="timeline-melee-text">Ready</span>
+                                </div>
+                            </div>
+                            <div class="timeline-track">
+                                <div class="timeline-label">Holy Strike</div>
+                                <div class="timeline-bar">
+                                    <div class="timeline-progress" id="timeline-holy-strike"></div>
+                                    <span class="timeline-text" id="timeline-holy-strike-text">Ready</span>
+                                </div>
+                            </div>
+                            <div class="timeline-track">
+                                <div class="timeline-label">Global Cooldown</div>
+                                <div class="timeline-bar">
+                                    <div class="timeline-progress" id="timeline-gcd"></div>
+                                    <span class="timeline-text" id="timeline-gcd-text">Open</span>
+                                </div>
+                            </div>
+                        </section>
+                        <section class="timeline-section">
+                            <h3 class="section-title">Buffs & Summons</h3>
+                            <div class="timeline-track aura">
+                                <div class="timeline-label">Windfury Aura</div>
+                                <div class="timeline-bar">
+                                    <div class="timeline-progress" id="timeline-windfury"></div>
+                                    <span class="timeline-text" id="timeline-windfury-text">Inactive</span>
+                                </div>
+                            </div>
+                            <div class="timeline-track column">
+                                <div class="timeline-label">Summons</div>
+                                <div class="timeline-summon-wrapper" id="summon-timeline-list">
+                                    <div class="timeline-empty">No active summons</div>
+                                </div>
+                            </div>
+                        </section>
                     </div>
-                </div>
+                </main>
+                <aside id="rules-column">
+                    <div id="combat-ai-panel">
+                        <h3 class="panel-title">Rules Editor</h3>
+                        <div class="panel-subtitle">IF / THEN List • Trigger % • Avg Value • Waste / Overlap</div>
+                        <div id="rules-metrics">
+                            <div class="metric">
+                                <span class="metric-label">Active Rules</span>
+                                <span class="metric-value" id="rule-count">0</span>
+                            </div>
+                            <div class="metric">
+                                <span class="metric-label">Automation Health</span>
+                                <span class="metric-value" id="rule-efficiency">Collecting</span>
+                            </div>
+                        </div>
+                        <div id="rules-list"></div>
+                        <button id="add-rule-btn">+ Add Rule</button>
+                    </div>
+                </aside>
             </div>
+            <footer id="event-feed">
+                <div class="panel-header">
+                    <h2>Collapsed Event Feed</h2>
+                    <div class="panel-subtitle">Chains grouped • Smite → Expose → Execute ×4</div>
+                </div>
+                <div id="combat-log"></div>
+            </footer>
         </div>
-        
-        <!-- Combat AI Panel -->
-        <div id="combat-ai-panel">
-            <h3>Combat AI Rules</h3>
-            <div id="rules-list"></div>
-            <button id="add-rule-btn">+ Add Rule</button>
-        </div>
-        
-        <div id="combat-log"></div>
         <script type="module" src="/src/main.ts"></script>
     </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { GameEngine } from './GameEngine';
 import { CONFIG } from './data/GameData';
 
 // ============================================
-// MAIN - Entry point
+// MAIN - Entry point & Run Controls
 // ============================================
 
 // Start the game
@@ -11,10 +11,128 @@ const game = new GameEngine();
 // Expose game instance to window for UI interaction
 (window as any).game = game;
 
-// Run game loop
-setInterval(() => {
-    game.tick();
-}, CONFIG.TICK_RATE);
+let isPaused = false;
+let speedMultiplier = 1;
+let tickHandle: number | null = null;
+let stepStatusTimeout: number | null = null;
+
+const runStatusEl = document.getElementById('run-status');
+const pauseBtn = document.getElementById('pause-btn') as HTMLButtonElement | null;
+const resumeBtn = document.getElementById('resume-btn') as HTMLButtonElement | null;
+const stepBtn = document.getElementById('step-btn') as HTMLButtonElement | null;
+const speedSelect = document.getElementById('speed-select') as HTMLSelectElement | null;
+const viewSelect = document.getElementById('view-select') as HTMLSelectElement | null;
+
+const formatSpeed = () => (Number.isInteger(speedMultiplier) ? speedMultiplier.toFixed(0) : speedMultiplier.toFixed(1));
+
+const updateRunStatus = (mode?: 'step') => {
+    if (!runStatusEl) {
+        return;
+    }
+
+    const formattedSpeed = formatSpeed();
+
+    if (mode === 'step') {
+        runStatusEl.textContent = `Step ×${formattedSpeed}`;
+        if (stepStatusTimeout !== null) {
+            window.clearTimeout(stepStatusTimeout);
+        }
+        stepStatusTimeout = window.setTimeout(() => {
+            stepStatusTimeout = null;
+            updateRunStatus();
+        }, 800);
+        return;
+    }
+
+    if (stepStatusTimeout !== null) {
+        window.clearTimeout(stepStatusTimeout);
+        stepStatusTimeout = null;
+    }
+
+    runStatusEl.textContent = `${isPaused ? 'Paused' : 'Running'} ×${formattedSpeed}`;
+};
+
+const updateControlStates = () => {
+    if (pauseBtn) {
+        pauseBtn.disabled = isPaused;
+    }
+    if (resumeBtn) {
+        resumeBtn.disabled = !isPaused;
+    }
+};
+
+const stopLoop = () => {
+    if (tickHandle !== null) {
+        window.clearInterval(tickHandle);
+        tickHandle = null;
+    }
+};
+
+const startLoop = () => {
+    stopLoop();
+    game.syncTime();
+    tickHandle = window.setInterval(() => {
+        game.tick();
+    }, CONFIG.TICK_RATE);
+};
+
+const pauseGame = () => {
+    if (isPaused) {
+        return;
+    }
+    isPaused = true;
+    stopLoop();
+    updateControlStates();
+    updateRunStatus();
+};
+
+const resumeGame = () => {
+    if (!isPaused) {
+        return;
+    }
+    isPaused = false;
+    startLoop();
+    updateControlStates();
+    updateRunStatus();
+};
+
+// Initialise run state
+game.setTimeScale(speedMultiplier);
+startLoop();
+updateControlStates();
+updateRunStatus();
+
+pauseBtn?.addEventListener('click', () => {
+    pauseGame();
+});
+
+resumeBtn?.addEventListener('click', () => {
+    resumeGame();
+});
+
+stepBtn?.addEventListener('click', () => {
+    if (!isPaused) {
+        pauseGame();
+    } else {
+        stopLoop();
+    }
+    game.stepSimulation(CONFIG.TICK_RATE);
+    updateRunStatus('step');
+});
+
+speedSelect?.addEventListener('change', (event) => {
+    const value = parseFloat((event.target as HTMLSelectElement).value);
+    if (!Number.isNaN(value)) {
+        speedMultiplier = value;
+        game.setTimeScale(speedMultiplier);
+        updateRunStatus();
+    }
+});
+
+viewSelect?.addEventListener('change', (event) => {
+    const mode = (event.target as HTMLSelectElement).value as 'mixed' | 'timeline' | 'arena';
+    game.setViewMode(mode);
+});
 
 // Log that game started
 console.log('Game started! Tick rate:', CONFIG.TICK_RATE + 'ms');


### PR DESCRIPTION
## Summary
- rebuild the HTML surface into the telemetry-first console with header run controls, entity stack, timelines, rules column, and event feed
- update the game engine to feed the new UI (stat cards, timelines, view toggling) and add time scaling helpers for pause/step support
- wire the pause/resume/step, speed, and view selectors in the entry point so the new controls drive the engine

## Testing
- npx tsc --noEmit
- npx vite --clearScreen false

------
https://chatgpt.com/codex/tasks/task_e_68cbba0b7cbc8332a51722bfcac9069c