### PR TITLE
Refactor UI into telemetry layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,56 +1,563 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <title>Idle ARPG - Combat Test </title>
+        <title>Idle ARPG - Combat Telemetry</title>
         <style>
+            :root {
+                color-scheme: dark;
+                --bg-void: #05060a;
+                --bg-panel: #0b1220;
+                --bg-elevated: #111827;
+                --bg-header: #0f172a;
+                --border-muted: #1f2937;
+                --border-bright: #38bdf8;
+                --text-primary: #e5e7eb;
+                --text-secondary: #94a3b8;
+                --accent-gold: #facc15;
+            }
+
+            * {
+                box-sizing: border-box;
+            }
+
             body {
-                font-family: monospace;
-                background: #0f0f0f;
-                color: #f8f5f5;
-                padding: 200px;
+                margin: 0;
+                background: var(--bg-void);
+                color: var(--text-primary);
+                font-family: "JetBrains Mono", "Fira Mono", "SFMono-Regular", monospace;
+                min-height: 100vh;
+                display: flex;
+                flex-direction: column;
             }
-            #combat-log {
-                height: 400px;
+
+            a {
+                color: inherit;
+            }
+
+            .app-shell {
+                display: flex;
+                flex-direction: column;
+                min-height: 100vh;
+            }
+
+            .telemetry-header {
+                display: flex;
+                justify-content: space-between;
+                align-items: flex-start;
+                gap: 24px;
+                padding: 20px 28px 16px;
+                background: var(--bg-header);
+                border-bottom: 1px solid var(--border-muted);
+            }
+
+            .title-block h1 {
+                margin: 0;
+                font-size: 20px;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+            }
+
+            .subtitle {
+                margin: 6px 0 0;
+                color: var(--text-secondary);
+                font-size: 12px;
+                letter-spacing: 0.04em;
+            }
+
+            .header-controls {
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
+                gap: 24px;
+                flex-wrap: wrap;
+            }
+
+            .run-controls {
+                display: flex;
+                align-items: center;
+                gap: 16px;
+                background: rgba(56, 189, 248, 0.06);
+                border: 1px solid rgba(56, 189, 248, 0.25);
+                padding: 10px 16px;
+                border-radius: 12px;
+                box-shadow: 0 10px 25px rgba(15, 23, 42, 0.35);
+            }
+
+            .control-btn {
+                background: rgba(56, 189, 248, 0.15);
+                border: 1px solid rgba(56, 189, 248, 0.55);
+                color: var(--text-primary);
+                font-size: 12px;
+                font-weight: 600;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+                padding: 8px 16px;
+                border-radius: 999px;
+                cursor: pointer;
+                transition: all 0.2s ease;
+            }
+
+            .control-btn:hover {
+                background: rgba(56, 189, 248, 0.25);
+                box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
+            }
+
+            .control-btn.active {
+                background: rgba(248, 113, 113, 0.25);
+                border-color: rgba(248, 113, 113, 0.6);
+                box-shadow: 0 0 0 2px rgba(248, 113, 113, 0.25);
+            }
+
+            .control-field {
+                display: flex;
+                flex-direction: column;
+                font-size: 10px;
+                letter-spacing: 0.12em;
+                text-transform: uppercase;
+                color: var(--text-secondary);
+                gap: 6px;
+            }
+
+            .control-field select {
+                background: var(--bg-panel);
+                border: 1px solid var(--border-muted);
+                color: var(--text-primary);
+                font-size: 12px;
+                padding: 6px 10px;
+                border-radius: 6px;
+            }
+
+            .utility-controls {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+                flex-wrap: wrap;
+            }
+
+            .utility-group {
+                position: relative;
+            }
+
+            .control-chip {
+                background: rgba(148, 163, 184, 0.15);
+                border: 1px solid rgba(148, 163, 184, 0.4);
+                color: var(--text-primary);
+                font-size: 11px;
+                letter-spacing: 0.18em;
+                text-transform: uppercase;
+                padding: 7px 18px;
+                border-radius: 999px;
+                cursor: pointer;
+                transition: all 0.2s ease;
+            }
+
+            .control-chip:hover {
+                border-color: rgba(56, 189, 248, 0.4);
+                color: rgba(248, 250, 252, 0.95);
+            }
+
+            .control-chip.active {
+                border-color: var(--border-bright);
+                color: rgba(248, 250, 252, 0.95);
+                box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
+            }
+
+            .utility-panel {
+                position: absolute;
+                top: calc(100% + 10px);
+                right: 0;
+                min-width: 320px;
+                background: var(--bg-panel);
+                border: 1px solid var(--border-muted);
+                border-radius: 12px;
+                padding: 14px;
+                box-shadow: 0 24px 48px rgba(15, 23, 42, 0.45);
+                display: none;
+                z-index: 200;
+                max-height: 420px;
                 overflow-y: auto;
-                border: 2px solid #130879;
-                padding: 10px;
-                margin-top: 20px;
             }
-            .damage { color: #ff6b6b; }
-            .heal { color: #51cf66; }
-            .mana { color: #339af0; }
-            .player-magic { color: #4dabf7; font-weight: bold; }
-            .system { color: #868e96; }
-            .melee { color: #ffa726; font-style: italic}
-            .loot { color: #ffd93d; font-weight: bold; }
-            
-            /* Windfury-specific styling */
-            .windfury {
-                background: linear-gradient(90deg, transparent, rgba(81, 207, 102, 0.1), transparent);
-                border-left: 2px solid #51cf66;
-                padding-left: 8px;
-                margin-left: -8px;
+
+            .utility-panel.open {
+                display: block;
             }
-            
-            /* Combat Arena */
-            #combat-arena {
+
+            .telemetry-grid {
+                flex: 1;
+                display: grid;
+                grid-template-columns: 310px 1fr 340px;
+                gap: 20px;
+                padding: 20px 28px;
+                overflow: hidden;
+            }
+
+            .entity-stack {
+                display: flex;
+                flex-direction: column;
+                gap: 16px;
+                background: var(--bg-elevated);
+                border: 1px solid var(--border-muted);
+                border-radius: 16px;
+                padding: 20px;
+                overflow-y: auto;
+            }
+
+            .entity-stack-header h2 {
+                margin: 0;
+                font-size: 16px;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+            }
+
+            .stack-caption {
+                font-size: 11px;
+                text-transform: uppercase;
+                letter-spacing: 0.16em;
+                color: var(--text-secondary);
+                margin-top: 6px;
+            }
+
+            .entity-card {
+                background: rgba(15, 23, 42, 0.7);
+                border: 1px solid rgba(148, 163, 184, 0.2);
+                border-radius: 12px;
+                padding: 16px;
+                display: flex;
+                flex-direction: column;
+                gap: 12px;
+                box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.1);
+            }
+
+            .entity-label {
+                font-size: 12px;
+                text-transform: uppercase;
+                letter-spacing: 0.24em;
+                color: var(--text-secondary);
+            }
+
+            .entity-telemetry {
+                display: flex;
+                flex-direction: column;
+                gap: 6px;
+                font-size: 12px;
+            }
+
+            .entity-telemetry .stat-line {
+                display: flex;
+                justify-content: space-between;
+                align-items: baseline;
+                gap: 16px;
+                color: var(--text-secondary);
+            }
+
+            .entity-telemetry .stat-line span:last-child {
+                color: var(--text-primary);
+            }
+
+            .entity-telemetry .gold-line span:last-child {
+                color: var(--accent-gold);
+                font-weight: 600;
+            }
+
+            .entity-telemetry .stat-highlight {
+                color: #34d399;
+                font-weight: 600;
+                margin-top: 6px;
+            }
+
+            .summons-card {
+                margin-top: 8px;
+                padding: 10px 12px;
+                border: 1px dashed rgba(148, 163, 184, 0.35);
+                border-radius: 10px;
+                background: rgba(15, 23, 42, 0.55);
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+            }
+
+            .summons-title {
+                text-transform: uppercase;
+                letter-spacing: 0.12em;
+                font-size: 11px;
+                color: rgba(226, 232, 240, 0.75);
+            }
+
+            .summon-line {
+                font-size: 12px;
+                color: rgba(226, 232, 240, 0.9);
+            }
+
+            .timeline-column {
+                display: flex;
+                flex-direction: column;
+                gap: 20px;
+                overflow: hidden;
+            }
+
+            .timeline-stage {
+                background: var(--bg-panel);
+                border: 1px solid var(--border-muted);
+                border-radius: 16px;
+                padding: 20px;
+                display: flex;
+                flex-direction: column;
+                gap: 20px;
+                min-height: 220px;
+            }
+
+            .timeline-header {
+                display: flex;
+                justify-content: space-between;
+                gap: 16px;
+                align-items: center;
+            }
+
+            .timeline-header h2 {
+                margin: 0;
+                text-transform: uppercase;
+                letter-spacing: 0.12em;
+                font-size: 14px;
+            }
+
+            .timeline-caption {
+                display: block;
+                margin-top: 6px;
+                font-size: 11px;
+                letter-spacing: 0.12em;
+                text-transform: uppercase;
+                color: var(--text-secondary);
+            }
+
+            .timeline-zoom {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                font-size: 11px;
+                color: var(--text-secondary);
+                text-transform: uppercase;
+                letter-spacing: 0.12em;
+            }
+
+            .timeline-zoom input[type="range"] {
+                width: 140px;
+            }
+
+            .timeline-body {
+                display: flex;
+                flex-direction: column;
+                gap: 14px;
+            }
+
+            .timeline-track {
+                display: flex;
+                gap: 12px;
+                align-items: stretch;
+            }
+
+            .track-label {
+                width: 110px;
+                font-size: 11px;
+                text-transform: uppercase;
+                letter-spacing: 0.16em;
+                color: var(--text-secondary);
+            }
+
+            .track-content {
+                flex: 1;
+                border: 1px dashed rgba(56, 189, 248, 0.2);
+                border-radius: 12px;
+                padding: 12px;
+                background: rgba(15, 23, 42, 0.55);
+                min-height: 56px;
+                display: flex;
+                align-items: center;
+                justify-content: flex-start;
+            }
+
+            .timeline-placeholder {
+                color: var(--text-secondary);
+                font-size: 12px;
+                letter-spacing: 0.08em;
+                text-transform: uppercase;
+            }
+
+            .track-content.aura-track {
+                color: rgba(94, 234, 212, 0.8);
+                font-size: 12px;
+            }
+
+            .ability-cooldowns {
+                display: flex;
+                gap: 14px;
+                flex-wrap: wrap;
+            }
+
+            .ability-icon {
+                width: 48px;
+                height: 48px;
+                position: relative;
+                border: 2px solid #38bdf8;
+                border-radius: 50%;
+                background: rgba(37, 99, 235, 0.08);
+                transition: transform 0.1s, box-shadow 0.2s;
+                user-select: none;
+                cursor: pointer;
+            }
+
+            .ability-icon:hover {
+                transform: scale(1.05);
+                box-shadow: 0 0 14px rgba(59, 130, 246, 0.45);
+            }
+
+            .ability-icon:active {
+                transform: scale(0.95);
+            }
+
+            .ability-icon.disabled {
+                opacity: 0.4;
+                cursor: not-allowed !important;
+                border-color: rgba(148, 163, 184, 0.35);
+            }
+
+            .ability-icon.disabled:hover {
+                transform: scale(1);
+                box-shadow: none;
+            }
+
+            .ability-icon[data-tooltip]::after {
+                content: attr(data-tooltip);
+                position: absolute;
+                left: 50%;
+                bottom: calc(100% + 10px);
+                transform: translateX(-50%);
+                background: rgba(15, 23, 42, 0.95);
+                border: 1px solid rgba(56, 189, 248, 0.4);
+                border-radius: 8px;
+                padding: 8px;
+                width: 240px;
+                color: var(--text-primary);
+                font-size: 11px;
+                letter-spacing: 0.03em;
+                white-space: pre-line;
+                pointer-events: none;
+                opacity: 0;
+                transition: opacity 0.15s ease;
+                z-index: 40;
+            }
+
+            .ability-icon:hover::after {
+                opacity: 1;
+            }
+
+            .ability-icon-content {
+                width: 100%;
+                height: 100%;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                font-size: 20px;
+                font-weight: bold;
+                color: #38bdf8;
+                position: relative;
+                z-index: 2;
+            }
+
+            .cooldown-overlay {
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                border-radius: 50%;
+                background: rgba(2, 6, 23, 0.7);
+                z-index: 3;
+            }
+
+            .cooldown-sweep {
+                position: absolute;
+                top: -2px;
+                left: -2px;
+                width: 52px;
+                height: 52px;
+                border-radius: 50%;
+                z-index: 4;
+            }
+
+            .cooldown-text {
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                transform: translate(-50%, -50%);
+                color: white;
+                font-size: 14px;
+                font-weight: bold;
+                text-shadow: 1px 1px 2px black;
+                z-index: 5;
+            }
+
+            .ability-ready {
+                animation: pulse-ready 1.2s ease-in-out infinite;
+            }
+
+            @keyframes pulse-ready {
+                0%, 100% { box-shadow: 0 0 6px rgba(59, 130, 246, 0.6); }
+                50% { box-shadow: 0 0 18px rgba(59, 130, 246, 0.9), 0 0 28px rgba(59, 130, 246, 0.6); }
+            }
+
+            .aura-track .sparkline {
+                display: inline-flex;
+                align-items: center;
+                gap: 8px;
+            }
+
+            .arena-stage {
+                background: var(--bg-panel);
+                border: 1px solid var(--border-muted);
+                border-radius: 16px;
+                padding: 20px;
+                display: flex;
+                flex-direction: column;
+                gap: 16px;
+                flex: 1;
+                min-height: 320px;
+            }
+
+            .arena-header {
                 display: flex;
                 justify-content: space-between;
                 align-items: center;
-                padding: 40px;
-                background: #000000;
-                border: 2px solid #333;
-                margin: 20px 0;
-                min-height: 200px;
+                font-size: 11px;
+                text-transform: uppercase;
+                letter-spacing: 0.14em;
+                color: var(--text-secondary);
+            }
+
+            .arena-header h2 {
+                margin: 0;
+                font-size: 14px;
+                letter-spacing: 0.12em;
+                text-transform: uppercase;
+                color: var(--text-primary);
+            }
+
+            #combat-arena {
                 position: relative;
+                flex: 1;
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                padding: 36px;
+                background: radial-gradient(circle at 50% 50%, rgba(30, 41, 59, 0.75), rgba(15, 23, 42, 0.85));
+                border: 1px solid rgba(148, 163, 184, 0.18);
+                border-radius: 12px;
                 overflow: hidden;
             }
-            
-            /* ASCII Trees Background */
+
             .arena-trees {
                 position: absolute;
-                font-family: 'Courier New', monospace;
-                color: #1a331a;
+                font-family: "Courier New", monospace;
+                color: rgba(34, 197, 94, 0.15);
                 font-size: 14px;
                 line-height: 0.9;
                 white-space: pre;
@@ -58,152 +565,47 @@
                 pointer-events: none;
                 z-index: 1;
             }
-            
-            .trees-left {
-                left: 10px;
-                top: 50%;
-                transform: translateY(-50%);
-            }
-            
-            .trees-right {
-                right: 10px;
-                top: 50%;
-                transform: translateY(-50%);
-            }
-            
-            .trees-top {
-                top: 5px;
-                left: 50%;
-                transform: translateX(-50%);
-                display: flex;
-                gap: 40px;
-            }
-            
-            .trees-bottom {
-                bottom: 5px;
-                left: 50%;
-                transform: translateX(-50%);
-                display: flex;
-                gap: 50px;
-            }
-            
-            /* Character Containers */
+
             .character-slot {
                 display: flex;
                 flex-direction: column;
                 align-items: center;
-                gap: 10px;
+                gap: 12px;
                 position: relative;
                 z-index: 10;
             }
-            
-            /* Sprite Containers */
+
             .sprite-container {
-                width: 40px;
-                height: 45px;
+                width: 54px;
+                height: 56px;
                 display: flex;
                 align-items: center;
                 justify-content: center;
-                position: relative;
             }
-            
+
             .sprite {
-                font-size: 24px;
+                font-size: 28px;
                 font-weight: bold;
-                font-family: 'Courier New', monospace;
+                font-family: "Courier New", monospace;
                 user-select: none;
                 transition: transform 0.1s ease-out;
             }
-            
+
             #player-sprite {
-                color: #4a9eff;
-                text-shadow: 0 0 10px #4a9eff;
-                font-size: 28px;
+                color: #38bdf8;
+                text-shadow: 0 0 10px rgba(56, 189, 248, 0.8);
+                font-size: 32px;
             }
-            
+
             #enemy-sprite {
-                color: #f5f5dc;
-                text-shadow: 0 0 10px #ff4444;
-                font-size: 13px;
+                color: #f8fafc;
+                text-shadow: 0 0 10px rgba(248, 113, 113, 0.6);
+                font-size: 16px;
                 line-height: 0.8;
                 white-space: pre;
                 text-align: center;
-                font-family: 'Courier New', monospace;
             }
-            
-            /* Remove idle floating animation 
-            @keyframes idle-float {
-                0%, 100% { transform: translateY(0); }
-                50% { transform: translateY(-3px); }
-            }
-            */
-            
-            /* Attack animations - CRUNCHIER */
-            .attacking {
-                animation: attack-lunge 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55) !important;
-            }
-            
-            @keyframes attack-lunge {
-                0% { transform: translateX(0) scale(1); }
-                40% { transform: translateX(15px) scale(1.3); }
-                100% { transform: translateX(0) scale(1); }
-            }
-            
-            .enemy-attacking {
-                animation: enemy-attack-lunge 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55) !important;
-            }
-            
-            @keyframes enemy-attack-lunge {
-                0% { transform: translateX(0) scale(1); }
-                40% { transform: translateX(-15px) scale(1.3); }
-                100% { transform: translateX(0) scale(1); }
-            }
-            
-            /* Damage taken animation - CRUNCHIER */
-            .damaged {
-                animation: damage-flash 0.15s !important;
-            }
-            
-            @keyframes damage-flash {
-                0% { transform: scale(1); filter: brightness(1); }
-                50% { transform: scale(0.9); filter: brightness(2) hue-rotate(180deg); }
-                100% { transform: scale(1); filter: brightness(1); }
-            }
-            
-            /* Health and Mana Bars */
-            .bar-container {
-                width: 100px;
-                height: 14px;
-                background: #1a1a1a;
-                border: 1px solid #444;
-                position: relative;
-            }
-            
-            .health-bar {
-                height: 100%;
-                background: linear-gradient(to right, #c62828, #ef5350);
-                transition: width 0.3s ease;
-                position: relative;
-            }
-            
-            .mana-bar {
-                height: 100%;
-                background: linear-gradient(to right, #1565c0, #42a5f5);
-                transition: width 0.3s ease;
-            }
-            
-            .bar-text {
-                position: absolute;
-                width: 100%;
-                text-align: center;
-                font-size: 10px;
-                line-height: 14px;
-                color: white;
-                text-shadow: 1px 1px 2px black;
-                pointer-events: none;
-            }
-            
-            /* Damage Splats - RuneScape Style */
+
             .damage-splat {
                 position: absolute;
                 width: 50px;
@@ -212,13 +614,13 @@
                 z-index: 100;
                 animation: splat-appear 0.05s cubic-bezier(0.175, 0.885, 0.32, 1.275);
             }
-            
+
             .splat-bg {
                 position: absolute;
                 width: 100%;
                 height: 100%;
             }
-            
+
             .splat-text {
                 position: absolute;
                 width: 100%;
@@ -232,379 +634,446 @@
                 text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.9), -1px -1px 2px rgba(0, 0, 0, 0.9);
                 pointer-events: none;
             }
-            
+
             @keyframes splat-appear {
-                0% {
-                    transform: scale(0);
-                }
-                100% {
-                    transform: scale(1);
-                }
+                0% { transform: scale(0); }
+                100% { transform: scale(1); }
             }
-            
-            /* Old damage number styles - keeping for reference */
-            .damage-number {
+
+            @keyframes attack-lunge {
+                0% { transform: translateX(0) scale(1); }
+                40% { transform: translateX(15px) scale(1.3); }
+                100% { transform: translateX(0) scale(1); }
+            }
+
+            .attacking {
+                animation: attack-lunge 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55) !important;
+            }
+
+            @keyframes enemy-attack-lunge {
+                0% { transform: translateX(0) scale(1); }
+                40% { transform: translateX(-15px) scale(1.3); }
+                100% { transform: translateX(0) scale(1); }
+            }
+
+            .enemy-attacking {
+                animation: enemy-attack-lunge 0.2s cubic-bezier(0.68, -0.55, 0.265, 1.55) !important;
+            }
+
+            @keyframes damage-flash {
+                0% { transform: scale(1); filter: brightness(1); }
+                50% { transform: scale(0.9); filter: brightness(2) hue-rotate(180deg); }
+                100% { transform: scale(1); filter: brightness(1); }
+            }
+
+            .damaged {
+                animation: damage-flash 0.15s !important;
+            }
+
+            .bar-container {
+                width: 100%;
+                height: 14px;
+                background: rgba(15, 23, 42, 0.8);
+                border: 1px solid rgba(148, 163, 184, 0.35);
+                position: relative;
+                border-radius: 999px;
+                overflow: hidden;
+            }
+
+            .health-bar {
+                height: 100%;
+                background: linear-gradient(to right, #dc2626, #f97316);
+                transition: width 0.3s ease;
+                position: relative;
+            }
+
+            .mana-bar {
+                height: 100%;
+                background: linear-gradient(to right, #0ea5e9, #6366f1);
+                transition: width 0.3s ease;
+            }
+
+            .bar-text {
                 position: absolute;
-                font-size: 20px;
-                font-weight: bold;
+                width: 100%;
+                text-align: center;
+                font-size: 10px;
+                line-height: 14px;
+                color: white;
+                text-shadow: 1px 1px 2px black;
                 pointer-events: none;
-                z-index: 100;
-                opacity: 1;
-                transition: opacity 0.2s ease-out, top 0.15s ease-out;
-                text-shadow: 2px 2px 2px rgba(0, 0, 0, 0.9);
-                animation: pop-in 0.05s cubic-bezier(0.175, 0.885, 0.32, 1.275);
             }
-            
-            @keyframes pop-in {
-                0% {
-                    transform: scale(0);
-                }
-                100% {
-                    transform: scale(1);
-                }
+
+            #summon-container {
+                position: absolute;
+                left: 0;
+                bottom: 0;
+                width: 100%;
+                height: 100%;
+                pointer-events: none;
+                z-index: 8;
             }
-            
-            .damage-holy {
-                color: #64b5f6;
-                text-shadow: 0 0 4px #2196f3, 2px 2px 2px rgba(0, 0, 0, 0.9);
-            }
-            
-            .damage-physical {
-                color: #ffa726;
-                text-shadow: 0 0 4px #ff6600, 2px 2px 2px rgba(0, 0, 0, 0.9);
-            }
-            
-            .damage-enemy {
-                color: #ef5350;
-                text-shadow: 0 0 4px #c62828, 2px 2px 2px rgba(0, 0, 0, 0.9);
-            }
-            
-            /* Stats Display */
-            #stats {
+
+            .rules-column {
+                background: var(--bg-elevated);
+                border: 1px solid var(--border-muted);
+                border-radius: 16px;
+                padding: 20px;
                 display: flex;
-                justify-content: space-between;
-                gap: 20px;
-                margin-bottom: 20px;
+                flex-direction: column;
+                gap: 16px;
+                overflow: hidden;
             }
-            
-            .stats-panel {
-                background: #2a2a2a;
-                border: 1px solid #444;
-                padding: 10px;
-                flex: 1;
+
+            .rules-column h2 {
+                margin: 0;
+                font-size: 16px;
+                letter-spacing: 0.12em;
+                text-transform: uppercase;
             }
-            
-            .player-stats {
-                text-align: left;
-            }
-            
-            .enemy-stats {
-                text-align: right;
-            }
-            
-            /* Combat AI Panel */
+
             #combat-ai-panel {
-                background: #2a2a2a;
-                border: 1px solid #444;
-                padding: 15px;
-                margin-top: 20px;
+                flex: 1;
+                display: flex;
+                flex-direction: column;
+                gap: 12px;
+                background: rgba(15, 23, 42, 0.55);
+                border: 1px solid rgba(148, 163, 184, 0.2);
+                border-radius: 12px;
+                padding: 16px;
             }
-            
+
             #combat-ai-panel h3 {
-                margin-top: 0;
-                color: #4a9eff;
+                margin: 0;
+                text-transform: uppercase;
+                letter-spacing: 0.16em;
+                font-size: 12px;
+                color: rgba(94, 234, 212, 0.8);
             }
-            
+
+            #rules-list {
+                flex: 1;
+                overflow-y: auto;
+                display: flex;
+                flex-direction: column;
+                gap: 10px;
+                padding-right: 4px;
+            }
+
             .ai-rule {
-                background: #1a1a1a;
-                border: 1px solid #333;
+                background: rgba(15, 23, 42, 0.75);
+                border: 1px solid rgba(148, 163, 184, 0.25);
+                border-radius: 10px;
                 padding: 10px;
-                margin: 10px 0;
                 display: flex;
                 align-items: center;
                 gap: 10px;
             }
-            
+
             .rule-priority {
-                color: #868e96;
+                color: rgba(148, 163, 184, 0.8);
                 font-weight: bold;
-                margin-right: 5px;
+                margin-right: 4px;
             }
-            
+
             .rule-controls {
                 display: flex;
                 flex-direction: column;
-                gap: 2px;
+                gap: 4px;
             }
-            
+
             .rule-controls button {
-                background: #333;
-                border: 1px solid #555;
-                color: white;
+                background: rgba(30, 41, 59, 0.8);
+                border: 1px solid rgba(148, 163, 184, 0.35);
+                color: var(--text-primary);
                 cursor: pointer;
                 padding: 2px 6px;
                 font-size: 10px;
+                border-radius: 6px;
             }
-            
+
             .rule-controls button:hover {
-                background: #444;
+                background: rgba(56, 189, 248, 0.15);
             }
-            
+
             .rule-content {
                 flex: 1;
                 display: flex;
                 align-items: center;
-                gap: 5px;
+                gap: 6px;
+                flex-wrap: wrap;
             }
-            
-            .rule-content input {
-                width: 50px;
-                background: #333;
-                border: 1px solid #555;
-                color: white;
-                padding: 2px 5px;
-            }
-            
+
+            .rule-content input,
             .rule-content select {
-                background: #333;
-                border: 1px solid #555;
-                color: white;
-                padding: 2px 5px;
+                background: rgba(15, 23, 42, 0.8);
+                border: 1px solid rgba(148, 163, 184, 0.35);
+                color: var(--text-primary);
+                padding: 2px 6px;
+                border-radius: 6px;
+                font-size: 11px;
             }
-            
+
             .rule-delete {
-                background: #8b0000;
-                border: 1px solid #a00;
-                color: white;
+                background: rgba(248, 113, 113, 0.15);
+                border: 1px solid rgba(248, 113, 113, 0.45);
+                color: #fca5a5;
                 cursor: pointer;
-                padding: 2px 8px;
+                padding: 3px 8px;
+                border-radius: 8px;
+                font-size: 11px;
             }
-            
+
             .rule-delete:hover {
-                background: #a00;
+                background: rgba(248, 113, 113, 0.25);
             }
-            
+
             #add-rule-btn {
-                background: #4a9eff;
-                border: none;
-                color: white;
-                padding: 5px 15px;
+                align-self: flex-start;
+                background: rgba(56, 189, 248, 0.2);
+                border: 1px solid rgba(56, 189, 248, 0.5);
+                color: var(--text-primary);
+                padding: 6px 14px;
                 cursor: pointer;
-                margin-top: 10px;
+                border-radius: 999px;
+                text-transform: uppercase;
+                letter-spacing: 0.16em;
+                font-size: 10px;
             }
-            
+
             #add-rule-btn:hover {
-                background: #5ab0ff;
+                background: rgba(56, 189, 248, 0.3);
             }
-            
-            /* Ability Cooldown Display */
-            .ability-cooldowns {
+
+            .event-feed {
+                background: rgba(3, 7, 18, 0.9);
+                border-top: 1px solid var(--border-muted);
+                padding: 16px 28px 24px;
+            }
+
+            .feed-header {
                 display: flex;
-                gap: 10px;
-                margin-top: 10px;
+                justify-content: space-between;
+                align-items: baseline;
+                margin-bottom: 12px;
             }
-            
-            .ability-icon {
-                width: 48px;
-                height: 48px;
-                position: relative;
-                border: 2px solid #4a9eff;
-                border-radius: 50%;
-                background: #1a1a1a;
-                transition: transform 0.1s, box-shadow 0.2s;
-                user-select: none;
+
+            .feed-header h2 {
+                margin: 0;
+                font-size: 13px;
+                letter-spacing: 0.16em;
+                text-transform: uppercase;
             }
-            
-            .ability-icon:hover {
-                transform: scale(1.05);
-                box-shadow: 0 0 10px rgba(74, 158, 255, 0.5);
+
+            .feed-caption {
+                font-size: 11px;
+                text-transform: uppercase;
+                letter-spacing: 0.12em;
+                color: var(--text-secondary);
             }
-            
-            .ability-icon:active {
-                transform: scale(0.95);
-            }
-            
-            .ability-icon.disabled {
-                opacity: 0.5;
-                cursor: not-allowed !important;
-            }
-            
-            .ability-icon.disabled:hover {
-                transform: scale(1);
-                box-shadow: none;
-            }
-            
-            .ability-icon:hover::after {
-                content: attr(data-tooltip);
-                position: absolute;
-                bottom: 60px;
-                left: 50%;
-                transform: translateX(-50%);
-                background: #2a2a2a;
-                border: 1px solid #444;
-                padding: 8px;
-                border-radius: 4px;
-                white-space: pre-line;
-                width: 250px;
+
+            #combat-log {
+                max-height: 180px;
+                overflow-y: auto;
+                border: 1px solid rgba(148, 163, 184, 0.2);
+                border-radius: 12px;
+                padding: 12px;
+                background: rgba(15, 23, 42, 0.5);
                 font-size: 12px;
-                z-index: 100;
-                pointer-events: none;
-            }
-            
-            .ability-icon-content {
-                width: 100%;
-                height: 100%;
                 display: flex;
-                align-items: center;
-                justify-content: center;
-                font-size: 20px;
-                font-weight: bold;
-                color: #4a9eff;
-                position: relative;
-                z-index: 2;
+                flex-direction: column;
+                gap: 4px;
             }
-            
-            /* Cooldown overlay - darkens the ability when on cooldown */
-            .cooldown-overlay {
-                position: absolute;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
-                border-radius: 50%;
-                background: rgba(0, 0, 0, 0.7);
-                z-index: 3;
+
+            .damage { color: #f87171; }
+            .heal { color: #34d399; }
+            .mana { color: #38bdf8; }
+            .player-magic { color: #60a5fa; font-weight: bold; }
+            .system { color: #94a3b8; }
+            .melee { color: #fb923c; font-style: italic; }
+            .loot { color: var(--accent-gold); font-weight: bold; }
+
+            .windfury {
+                background: linear-gradient(90deg, transparent, rgba(34, 197, 94, 0.12), transparent);
+                border-left: 2px solid rgba(34, 197, 94, 0.5);
+                padding-left: 8px;
             }
-            
-            /* Cooldown sweep - the filling circle effect */
-            .cooldown-sweep {
-                position: absolute;
-                top: -2px;
-                left: -2px;
-                width: 52px;
-                height: 52px;
-                border-radius: 50%;
-                z-index: 4;
-            }
-            
-            .cooldown-text {
-                position: absolute;
-                top: 50%;
-                left: 50%;
-                transform: translate(-50%, -50%);
-                color: white;
-                font-size: 14px;
-                font-weight: bold;
-                text-shadow: 1px 1px 2px black;
-                z-index: 5;
-            }
-            
-            .ability-ready {
-                animation: pulse-ready 1s ease-in-out infinite;
-            }
-            
-            @keyframes pulse-ready {
-                0%, 100% { box-shadow: 0 0 5px #4a9eff; }
-                50% { box-shadow: 0 0 15px #4a9eff, 0 0 25px #4a9eff; }
-            }
-            
-            .aura-active {
-                animation: aura-pulse 2s ease-in-out infinite;
-            }
-            
-            @keyframes aura-pulse {
-                0%, 100% { box-shadow: 0 0 10px #51cf66; }
-                50% { box-shadow: 0 0 20px #51cf66, 0 0 30px #51cf66; }
-            }
-            
-            @keyframes ability-activate {
-                0% { box-shadow: 0 0 0 0 rgba(74, 158, 255, 0.7); }
-                70% { box-shadow: 0 0 0 15px rgba(74, 158, 255, 0); }
-                100% { box-shadow: 0 0 0 0 rgba(74, 158, 255, 0); }
-            }
-            
-            .ability-activate {
-                animation: ability-activate 0.4s;
+
+            @media (max-width: 1200px) {
+                .telemetry-grid {
+                    grid-template-columns: 1fr;
+                }
+
+                .rules-column {
+                    order: 3;
+                }
+
+                .entity-stack {
+                    order: 1;
+                }
+
+                .timeline-column {
+                    order: 2;
+                }
             }
         </style>
     </head>
-    <body>
-        <div id="stats">
-            <div class="stats-panel player-stats" id="player-stats"></div>
-            <div class="stats-panel enemy-stats" id="enemy-stats"></div>
-        </div>
-        
-        <!-- Combat Arena -->
-        <div id="combat-arena">
-            <!-- ASCII Trees Background -->
-            <div class="arena-trees" style="color: #2d5a2d; left: 10px; top: 20%;">    /\
+    <body data-view="live">
+        <div class="app-shell">
+            <header class="telemetry-header">
+                <div class="title-block">
+                    <h1>Stat-Sim UI (Telemetry-First)</h1>
+                    <p class="subtitle">Idle ARPG instrumentation harness</p>
+                </div>
+                <div class="header-controls">
+                    <div class="run-controls">
+                        <button id="pause-btn" class="control-btn">Pause</button>
+                        <label class="control-field">
+                            <span>Speed</span>
+                            <select id="speed-select">
+                                <option value="1">1x</option>
+                                <option value="2">2x</option>
+                                <option value="4">4x</option>
+                                <option value="8">8x</option>
+                            </select>
+                        </label>
+                        <label class="control-field">
+                            <span>View</span>
+                            <select id="view-select">
+                                <option value="live" selected>Live Combat</option>
+                                <option value="stats">Stats Focus</option>
+                                <option value="loot">Loot Review</option>
+                            </select>
+                        </label>
+                    </div>
+                    <div class="utility-controls" id="utility-controls"></div>
+                </div>
+            </header>
+            <main class="telemetry-grid">
+                <aside class="entity-stack">
+                    <div class="entity-stack-header">
+                        <h2>Entity Stack</h2>
+                        <div class="stack-caption">Actors · HP/MP · Buff streams</div>
+                    </div>
+                    <div class="entity-card" id="player-card">
+                        <div class="entity-label">Player</div>
+                        <div class="bar-block">
+                            <div class="bar-container">
+                                <div id="player-health-bar" class="health-bar" style="width: 100%">
+                                    <div class="bar-text">100/100</div>
+                                </div>
+                            </div>
+                            <div class="bar-container" style="margin-top: 8px;">
+                                <div id="player-mana-bar" class="mana-bar" style="width: 100%">
+                                    <div class="bar-text">100/100</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="entity-telemetry" id="player-stats"></div>
+                    </div>
+                    <div class="entity-card" id="enemy-card">
+                        <div class="entity-label">Enemy</div>
+                        <div class="bar-block">
+                            <div class="bar-container">
+                                <div id="enemy-health-bar" class="health-bar" style="width: 100%">
+                                    <div class="bar-text">100/100</div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="entity-telemetry" id="enemy-stats"></div>
+                    </div>
+                </aside>
+                <section class="timeline-column">
+                    <div class="timeline-stage">
+                        <div class="timeline-header">
+                            <div>
+                                <h2>Timelines</h2>
+                                <span class="timeline-caption">Casts · CDs · Buff/Debuff bands · Proc pulses</span>
+                            </div>
+                            <div class="timeline-zoom">
+                                <label for="timeline-zoom">Zoom</label>
+                                <input id="timeline-zoom" type="range" min="5" max="60" value="15" />
+                                <span class="zoom-readout" id="zoom-readout">15s</span>
+                            </div>
+                        </div>
+                        <div class="timeline-body">
+                            <div class="timeline-track">
+                                <div class="track-label">Rotation</div>
+                                <div class="track-content" id="rotation-track">
+                                    <div class="timeline-placeholder">Ability telemetry initialising…</div>
+                                </div>
+                            </div>
+                            <div class="timeline-track">
+                                <div class="track-label">Auras &amp; Procs</div>
+                                <div class="track-content aura-track">
+                                    <div class="sparkline" id="aura-sparkline">Aura idle — toggle to engage.</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="arena-stage">
+                        <div class="arena-header">
+                            <h2>Combat View</h2>
+                            <span>Chains grouped · Smite→Expose→Execute ×4</span>
+                        </div>
+                        <div id="combat-arena">
+                            <div class="arena-trees" style="left: 12px; top: 20%;">    /\
    /--\
   /----\</div>
-            <div class="arena-trees" style="color: #1f4a1f; left: 80px; top: 60%;">   /\
+                            <div class="arena-trees" style="left: 90px; top: 58%;">   /\
   /--\
  /----\</div>
-            <div class="arena-trees" style="color: #2d5a2d; right: 10px; top: 25%;">    /\
+                            <div class="arena-trees" style="right: 12px; top: 25%;">    /\
    /--\
   /----\</div>
-            <div class="arena-trees" style="color: #1f4a1f; right: 90px; top: 55%;">   /\
+                            <div class="arena-trees" style="right: 100px; top: 55%;">   /\
   /--\
  /----\</div>
-            <div class="arena-trees" style="color: #1a331a; top: 10px; left: 20%;">  /\
+                            <div class="arena-trees" style="top: 12px; left: 28%;">  /\
  /--\
 /----\</div>
-            <div class="arena-trees" style="color: #1a331a; top: 15px; right: 30%;">  /\
+                            <div class="arena-trees" style="top: 18px; right: 32%;">  /\
  /--\
 /----\</div>
-            <div class="arena-trees" style="color: #1f4a1f; bottom: 20px; left: 25%;">  /\
+                            <div class="arena-trees" style="bottom: 18px; left: 26%;">  /\
  /--\
 /----\</div>
-            <div class="arena-trees" style="color: #1f4a1f; bottom: 25px; right: 20%;">  /\
+                            <div class="arena-trees" style="bottom: 22px; right: 24%;">  /\
  /--\
 /----\</div>
-            
-            <!-- Player Side -->
-            <div class="character-slot">
-                <div class="sprite-container">
-                    <div id="player-sprite" class="sprite">✦</div>
-                </div>
-                <div class="bar-container">
-                    <div id="player-health-bar" class="health-bar" style="width: 100%">
-                        <div class="bar-text">100/100</div>
+                            <div class="character-slot">
+                                <div class="sprite-container">
+                                    <div id="player-sprite" class="sprite">✦</div>
+                                </div>
+                            </div>
+                            <div id="summon-container"></div>
+                            <div class="character-slot">
+                                <div class="sprite-container">
+                                    <div id="enemy-sprite" class="sprite">0
+/|\\
+/\\</div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
-                </div>
-                <div class="bar-container">
-                    <div id="player-mana-bar" class="mana-bar" style="width: 100%">
-                        <div class="bar-text">100/100</div>
+                </section>
+                <aside class="rules-column">
+                    <h2>Rules Editor</h2>
+                    <div id="combat-ai-panel">
+                        <h3>Combat AI Rules</h3>
+                        <div id="rules-list"></div>
+                        <button id="add-rule-btn">+ Add Rule</button>
                     </div>
+                </aside>
+            </main>
+            <footer class="event-feed">
+                <div class="feed-header">
+                    <h2>Collapsed Event Feed</h2>
+                    <span class="feed-caption">Rolling log · Trigger % · Waste/Overlap</span>
                 </div>
-            </div>
-            
-            <!-- Summon Container - positioned in front of player -->
-            <div id="summon-container" style="position: absolute; left: 0; bottom: 0; width: 100%; height: 100%; pointer-events: none; z-index: 8;"></div>
-            
-            <!-- Enemy Side -->
-            <div class="character-slot">
-                <div class="sprite-container">
-                    <div id="enemy-sprite" class="sprite">0
-/|\
-/\</div>
-                </div>
-                <div class="bar-container">
-                    <div id="enemy-health-bar" class="health-bar" style="width: 100%">
-                        <div class="bar-text">100/100</div>
-                    </div>
-                </div>
-            </div>
+                <div id="combat-log"></div>
+            </footer>
         </div>
-        
-        <!-- Combat AI Panel -->
-        <div id="combat-ai-panel">
-            <h3>Combat AI Rules</h3>
-            <div id="rules-list"></div>
-            <button id="add-rule-btn">+ Add Rule</button>
-        </div>
-        
-        <div id="combat-log"></div>
         <script type="module" src="/src/main.ts"></script>
     </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,19 +2,74 @@ import { GameEngine } from './GameEngine';
 import { CONFIG } from './data/GameData';
 
 // ============================================
-// MAIN - Entry point
+// MAIN - Entry point with telemetry controls
 // ============================================
 
-// Start the game
 const game = new GameEngine();
-
-// Expose game instance to window for UI interaction
 (window as any).game = game;
 
-// Run game loop
-setInterval(() => {
-    game.tick();
-}, CONFIG.TICK_RATE);
+let isPaused = false;
+let speedMultiplier = 1;
+const baseTickRate = CONFIG.TICK_RATE;
+let tickInterval: number | undefined;
 
-// Log that game started
-console.log('Game started! Tick rate:', CONFIG.TICK_RATE + 'ms');
+const runTick = () => {
+    if (!isPaused) {
+        game.tick();
+    }
+};
+
+const startLoop = () => {
+    if (tickInterval !== undefined) {
+        clearInterval(tickInterval);
+    }
+
+    const intervalRate = Math.max(16, Math.round(baseTickRate / speedMultiplier));
+    tickInterval = window.setInterval(runTick, intervalRate);
+};
+
+startLoop();
+
+const pauseBtn = document.getElementById('pause-btn');
+if (pauseBtn) {
+    pauseBtn.addEventListener('click', () => {
+        isPaused = !isPaused;
+        pauseBtn.textContent = isPaused ? 'Resume' : 'Pause';
+        pauseBtn.classList.toggle('active', isPaused);
+    });
+}
+
+const speedSelect = document.getElementById('speed-select') as HTMLSelectElement | null;
+if (speedSelect) {
+    speedSelect.addEventListener('change', () => {
+        const value = parseFloat(speedSelect.value);
+        speedMultiplier = isNaN(value) ? 1 : value;
+        startLoop();
+    });
+}
+
+const viewSelect = document.getElementById('view-select') as HTMLSelectElement | null;
+if (viewSelect) {
+    const setView = (value: string) => {
+        document.body.setAttribute('data-view', value);
+    };
+
+    setView(viewSelect.value);
+
+    viewSelect.addEventListener('change', () => {
+        setView(viewSelect.value);
+    });
+}
+
+const zoomInput = document.getElementById('timeline-zoom') as HTMLInputElement | null;
+const zoomReadout = document.getElementById('zoom-readout');
+if (zoomInput && zoomReadout) {
+    const updateZoom = () => {
+        zoomReadout.textContent = `${zoomInput.value}s`;
+    };
+
+    updateZoom();
+    zoomInput.addEventListener('input', updateZoom);
+}
+
+console.log('Game started! Tick rate:', `${CONFIG.TICK_RATE}ms`);


### PR DESCRIPTION
## Summary
- rebuild the HTML shell into a telemetry-first layout with header controls, entity stack sidebar, timeline center stage, and rules/event columns to match the requested wireframe
- relocate inventory and shop controls into the new header utility dock and update combat stats rendering to feed the new timeline/stack panels
- add pause/speed/view/zoom controls that drive the game loop and timeline readout for interactive telemetry adjustments

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cbba0b7cbc8332a51722bfcac9069c